### PR TITLE
Update Dockerfile to run migrations on build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,5 @@ COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
+RUN alembic upgrade head
 CMD [ "bash", "run_prod.sh", "--bind", "0.0.0.0:80" ]


### PR DESCRIPTION
Without this line, the newly built container can't register users
because the `users` table doesn't exist.

Fixes #5 